### PR TITLE
Fix links to go-ethereum and cannon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Siege
 
-This testing tool surrounds [go-ethereum](github.com/ethereum/go-ethereum) with [cannon](github.com/ethereum-optimism/cannon) 
+This testing tool surrounds [go-ethereum](https://github.com/ethereum/go-ethereum) with [cannon](https://github.com/ethereum-optimism/cannon) 
 to catch the blocks of [retesteth](https://github.com/ethereum/retesteth) going into go-ethereum and test cannon with them.
 
 ## Usage


### PR DESCRIPTION
Without the leading `https://`, Github will treat this like a relative path and target https://github.com/protolambda/siege/blob/master/github.com/ethereum/go-ethereum which doesn't exist

Please keep up the great work on all the Eth infra you contribute!